### PR TITLE
feat: add kyber support on KMS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+server/127.0.0.1+*
 .mongodata/
 temp_storage/
 .DS_Store

--- a/server/static/cse.js
+++ b/server/static/cse.js
@@ -142,6 +142,7 @@ window.onload = async function() {
         }
         const eDekArray = base64ToArrayBuffer(kmsWrapData.edek);
         const eDekData = new Uint8Array(eDekArray);
+        alert(`Encrypted DEK length: ${eDekData.byteLength}`);
         
 
         // Prepare the encrypted file for upload
@@ -230,10 +231,10 @@ window.onload = async function() {
             const blobArrayBuffer = await blob.arrayBuffer()
             const blobData = new Uint8Array(blobArrayBuffer);
             const iv = blobData.slice(0, 12);
-            const encryptedEDek = blobData.slice(12, 12+256);
-            const encryptedFile = blobData.slice(12+256);
+            const encryptedEDek = blobData.slice(12, 12+48);
+            const encryptedFile = blobData.slice(12+48);
             alert(`IV: ${btoa(String.fromCharCode(...iv))}`);
-            alert(`Encrypted DEK: ${btoa(String.fromCharCode(...encryptedEDek))}`);
+            // alert(`Encrypted DEK: ${btoa(String.fromCharCode(...encryptedEDek))}`);
             
             // Send eDek to KMS to unwrap it
             function arrayBufferToBase64(buffer) {
@@ -244,8 +245,9 @@ window.onload = async function() {
                 }
                 return btoa(binary);
             }
-            // alert(`Encrypted DEK length: ${encryptedEDek.byteLength}`);
             const encryptedEDekBase64 = arrayBufferToBase64(encryptedEDek);
+            alert(`Encrypted DEK length: ${encryptedEDek.byteLength}`);
+            alert(`Encrypted DEK Base64: ${encryptedEDekBase64}`);
 
             const kmsKEkResponse = await fetch(KMS_ADDRESS + "kms", {
                 method: "POST",

--- a/server/static/login.js
+++ b/server/static/login.js
@@ -28,7 +28,7 @@ document.getElementById("loginForm").onsubmit = async function(event) {
             document.getElementById("otp").focus(); // Focus on OTP field
             setTimeout(() => {
                 window.location.reload();
-            }, 6000); // Reload page
+            }, 60000); // Reload page
         } else {
             alert(data.message || "Login failed");
         }


### PR DESCRIPTION
Add kyber support on KMS to protect DEK.
KMS receive DEK from clients, generate kyber key pair, generate AES key from kyber key pair, encrypt DEK using AES key, then send the eDEK back to client.